### PR TITLE
Found the solution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  valkey:
+    image: valkey/valkey:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - valkey_data:/data
+
+  app:
+    image: node:alpine
+    init: true
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/opt
+    command: sh -c "rm -f /tmp/glide-socket* && /opt/entrypoint.sh"
+    depends_on:
+      - valkey
+
+volumes:
+  valkey_data:

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,28 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.externals = config.externals || [];
+
+      // Externalize anything from @valkey/valkey-glide
+      config.externals.push(
+        (context: any, request: string, callback: (error?: null, result?: string) => void) => {
+          if (request?.startsWith("@valkey/valkey-glide")) {
+            return callback(null, `commonjs ${request}`);
+          }
+          callback();
+        }
+      );
+    }
+
+    config.module.rules.push({
+      test: /\.node$/,
+      use: "node-loader",
+    });
+
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,21 +3,22 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
+    "@valkey/valkey-glide": "^1.2.1",
+    "next": "^15.1.6",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.1.6",
-		"@valkey/valkey-glide": "^1.2.1"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^19",
-    "@types/react-dom": "^19"
+    "@types/react-dom": "^19",
+    "node-loader": "^2.1.0",
+    "typescript": "^5"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,2 @@
-docker run --rm -it -p 3000:3000 -v ./:/opt node:alpine /opt/entrypoint.sh
+#!/bin/bash
+docker-compose up --build

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
-import { getValkey } from "./valkey";
+import client from "./valkey";
 
 export default function Home() {
 
   async function valkey() {
     'use server';
-    const valkey = getValkey();
+    const valkey = client;
   }
   valkey();
   return (

--- a/src/app/valkey.ts
+++ b/src/app/valkey.ts
@@ -1,22 +1,15 @@
-"use server";
 import { GlideClient } from "@valkey/valkey-glide";
-// When Valkey is in standalone mode, add address of the primary node, and any replicas you'd like to be able to read from.
+
 const addresses = [
-	{
-		host: "localhost",
-		port: 6379,
-	},
+  {
+    host: "valkey",
+    port: 6379,
+  },
 ];
-// Check `GlideClientConfiguration/GlideClusterClientConfiguration` for additional options.
+
 const client = await GlideClient.createClient({
-	addresses: addresses,
-	// if the server uses TLS, you'll need to enable it. Otherwise, the connection attempt will time out silently.
-	// useTLS: true,
-	clientName: "nextjs",
+  addresses: addresses,
+  clientName: "nextjs",
 });
 
-export const getValkey = async (): Promise<
-	ReturnType<typeof GlideClient.createClient>
-> => {
-	return client;
-};
+export default client;


### PR DESCRIPTION
Since the glide code is a native code, you need to specify in the next config to not pack it, and to load it on runtime on the server only.
Additionally, for the next challenge, if you don't clean the volume between runs, we currently have an issue with the socket files not being cleaned, so you need to add `rm -f /tmp/glide-socket*` to the entry command. I added a compose file doing all, and creating a valkey docker with a network between.